### PR TITLE
feat: rename viewable from client ui

### DIFF
--- a/client/src/dock.rs
+++ b/client/src/dock.rs
@@ -8,7 +8,9 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::{self, IntoScheduleConfigs, Schedulable, ScheduleConfigs};
 use bevy::ecs::system::{Command, Commands, ParamSet, Res, ResMut, RunSystemOnce, SystemParam};
 use bevy::ecs::world::World;
-use bevy_egui::{EguiContexts, EguiGlobalSettings, EguiPreUpdateSet, EguiPrimaryContextPass, PrimaryEguiContext};
+use bevy_egui::{
+    EguiContexts, EguiGlobalSettings, EguiPreUpdateSet, EguiPrimaryContextPass, PrimaryEguiContext,
+};
 use egui::WidgetText;
 use egui_dock::tab_viewer::OnCloseResponse;
 use egui_dock::{DockArea, DockState, TabPath};
@@ -37,7 +39,12 @@ impl Plugin for Plug {
         app.init_resource::<State>();
         app.init_resource::<Toasts>();
         app.add_systems(app::Startup, setup_system);
-        app.add_systems(app::PreUpdate, init_egui_system.after(EguiPreUpdateSet::InitContexts).before(EguiPreUpdateSet::BeginPass));
+        app.add_systems(
+            app::PreUpdate,
+            init_egui_system
+                .after(EguiPreUpdateSet::InitContexts)
+                .before(EguiPreUpdateSet::BeginPass),
+        );
         app.add_systems(EguiPrimaryContextPass, (render_system, render_toasts_system).chain());
     }
 }
@@ -46,7 +53,7 @@ impl Plugin for Plug {
 pub struct State(DockState<TabState>);
 
 #[derive(Resource, Default)]
-pub struct Toasts(egui_notify::Toasts);
+pub struct Toasts(pub egui_notify::Toasts);
 
 pub struct TabState {
     id:       u32,

--- a/client/src/dock/viewable_info.rs
+++ b/client/src/dock/viewable_info.rs
@@ -1,4 +1,5 @@
 use bevy::ecs::entity::Entity;
+use bevy::ecs::message::MessageWriter;
 use bevy::ecs::system::{Command, Commands, ParamSet, Query, SystemParam};
 use bevy::ecs::world::World;
 use egui_material_icons::icons;
@@ -6,7 +7,7 @@ use traffloat_physics::util::QueryExt;
 use traffloat_proto::proto;
 
 use crate::dock::{self, TabPlacement, viewable_info};
-use crate::scene::{self, FluidTypes, GenericViewable, ViewableKind};
+use crate::scene::{self, FluidTypes, GenericViewable, ProtoId, ViewableKind};
 use crate::util::new_id;
 
 mod building;
@@ -17,6 +18,7 @@ mod resident;
 
 pub struct Tab {
     pub entity: Entity,
+    ui_state:   UiState,
 }
 
 impl dock::Tab for Tab {
@@ -43,7 +45,7 @@ impl dock::Tab for Tab {
     ) {
         let mut generic = param.ps.p0();
 
-        let Ok(viewable) = generic.viewable_query.get(self.entity) else {
+        let Ok((viewable, &ProtoId(id))) = generic.viewable_query.get(self.entity) else {
             ui.label("Object has been unloaded");
             return;
         };
@@ -66,9 +68,38 @@ impl dock::Tab for Tab {
                 },
                 ViewableKind::Resident => "Resident:",
             });
-            ui.heading(&viewable.name);
-            if ui.button(icons::ICON_EDIT).on_hover_text("Rename").clicked() {
-                // TODO edit text
+            match self.ui_state.name_edit {
+                None => {
+                    ui.heading(&viewable.name);
+                    if ui.button(icons::ICON_EDIT).on_hover_text("Rename").clicked() {
+                        self.ui_state.name_edit = Some(viewable.name.clone());
+                    }
+                }
+                Some(ref mut name) => {
+                    let resp = egui::TextEdit::singleline(name)
+                        .font(egui::TextStyle::Heading)
+                        .show(ui)
+                        .response;
+                    let submit =
+                        resp.lost_focus() && resp.ctx.input(|i| i.key_pressed(egui::Key::Enter));
+                    let mut cancel = resp.lost_focus();
+
+                    let is_valid = !name.is_empty() && name != &viewable.name;
+                    ui.add_enabled_ui(is_valid, |ui| {
+                        if ui.button(icons::ICON_CHECK).on_hover_text("Confirm rename").clicked()
+                            || submit
+                        {
+                            generic.request_writer.write(scene::OutboundRequest {
+                                body: proto::RenameViewable { id, name: name.clone() }.into(),
+                            });
+                            cancel = true;
+                        }
+                    });
+
+                    if cancel {
+                        self.ui_state.name_edit = None;
+                    }
+                }
             }
         });
 
@@ -121,7 +152,13 @@ pub struct UiSystemParam<'w, 's> {
 struct GenericUiSystemParams<'w, 's> {
     commands:       Commands<'w, 's>,
     conduit_query:  Query<'w, 's, &'static scene::conduit::Info>,
-    viewable_query: Query<'w, 's, &'static GenericViewable>,
+    viewable_query: Query<'w, 's, (&'static GenericViewable, &'static ProtoId)>,
+    request_writer: MessageWriter<'w, scene::OutboundRequest>,
+}
+
+#[derive(Default)]
+struct UiState {
+    name_edit: Option<String>,
 }
 
 pub struct OpenCommand {
@@ -140,7 +177,7 @@ impl Command for OpenCommand {
     type Out = ();
     fn apply(self, world: &mut World) {
         world.resource_mut::<dock::State>().focus_or_create(
-            || viewable_info::Tab { entity: self.entity }.into(),
+            || viewable_info::Tab { entity: self.entity, ui_state: UiState::default() }.into(),
             dock::ReplaceTab(|state| state.tab.is_viewable_info())
                 .only_if(!self.force_new)
                 .or(dock::Split { split: egui_dock::Split::Right, ratio: 0.7 }

--- a/client/src/scene.rs
+++ b/client/src/scene.rs
@@ -18,6 +18,7 @@ use bevy::state::app::AppExtStates;
 use bevy::state::state::States;
 use bevy::transform::components::GlobalTransform;
 use bevy_mod_config::{AppExt, Config, ReadConfig};
+use egui_notify::Toast;
 use itertools::Itertools;
 use strum::IntoEnumIterator;
 use traffloat_macro_util::fan_out;
@@ -320,6 +321,7 @@ fan_out! {
     8, 2;
     SetFluidTypes(SetFluidTypesParams<'w>),
     SetResidentAttrTypes(resident::SetResidentAttrTypesParams<'w>),
+    ShowGenericToast(ShowGenericToastParams<'w>),
     NewBuilding(building::NewBuildingParams<'w, 's>),
     UpdateBuilding(building::UpdateBuildingParams<'w, 's>),
     UpdateBuildingFluidConnections(building::UpdateBuildingFluidConnectionsParams<'w, 's>),
@@ -335,6 +337,7 @@ fan_out! {
     UpdateResidentLocation(resident::UpdateResidentLocationParams<'w, 's>),
     UpdateResidentAttributesFull(resident::UpdateResidentAttributesFullParams<'w, 's>),
     UpdateResidentAttributesPartial(resident::UpdateResidentAttributesPartialParams<'w, 's>),
+    UpdateViewableName(UpdateViewableNameParams<'w, 's>),
     RemoveViewable(RemoveViewableParams<'w, 's>),
 }
 
@@ -354,6 +357,52 @@ impl UpdateHandler for SetFluidTypesParams<'_> {
 }
 
 #[derive(SystemParam)]
+struct ShowGenericToastParams<'w> {
+    toasts: ResMut<'w, dock::Toasts>,
+}
+
+impl UpdateHandler for ShowGenericToastParams<'_> {
+    type Update = proto::ShowGenericToast;
+
+    fn classify(_update: &Self::Update) -> HandlerClass { HandlerClass::Update }
+
+    fn handle(&mut self, update: &proto::ShowGenericToast) {
+        self.toasts.0.add(match update.ty {
+            proto::ToastType::Info => Toast::info(update.message.clone()),
+            proto::ToastType::Error => Toast::error(update.message.clone()),
+        });
+    }
+}
+
+#[derive(SystemParam)]
+struct UpdateViewableNameParams<'w, 's> {
+    ids:   ResMut<'w, IdRegistry>,
+    query: Query<'w, 's, &'static mut GenericViewable>,
+}
+
+impl UpdateHandler for UpdateViewableNameParams<'_, '_> {
+    type Update = proto::UpdateViewableName;
+
+    fn classify(_update: &Self::Update) -> HandlerClass { HandlerClass::Update }
+
+    fn handle(&mut self, update: &proto::UpdateViewableName) {
+        let Some(tracked) = self.ids.map.get(&update.id) else {
+            tracing::error!("Received name update for unknown viewable id {:?}", update.id);
+            return;
+        };
+        let entity = match tracked {
+            TrackedId::Building(entity)
+            | TrackedId::Corridor(entity)
+            | TrackedId::Facility(entity)
+            | TrackedId::Conduit(entity)
+            | TrackedId::Resident(entity) => *entity,
+        };
+        let Some(mut viewable) = self.query.log_get_mut(entity) else { return };
+        viewable.name.clone_from(&update.name);
+    }
+}
+
+#[derive(SystemParam)]
 struct RemoveViewableParams<'w, 's> {
     commands: Commands<'w, 's>,
     ids:      ResMut<'w, IdRegistry>,
@@ -366,7 +415,7 @@ impl UpdateHandler for RemoveViewableParams<'_, '_> {
 
     fn handle(&mut self, fixture: &proto::RemoveViewable) {
         let Some(tracked) = self.ids.map.remove(&fixture.id) else {
-            tracing::error!("Received remove for unknown fixture id {:?}", fixture.id);
+            tracing::error!("Received remove for unknown viewable id {:?}", fixture.id);
             return;
         };
         match tracked {

--- a/physics/src/graph/building.rs
+++ b/physics/src/graph/building.rs
@@ -47,7 +47,6 @@ impl Plugin for Plug {
 
 #[derive(Component, Reflect)]
 pub struct Building {
-    pub name:           String,
     pub position:       Vector,
     pub radius:         f32,
     pub wall_thickness: f32,
@@ -74,15 +73,15 @@ impl EntityCommand for SpawnCommand {
         let ambient_volume = sphere_volume(self.radius);
 
         let building = Building {
-            name: self.name,
             position: self.position,
             radius: self.radius,
             wall_thickness: self.wall_thickness,
             ambient_volume,
         };
         entity.insert((
-            Name::new(format!("Building {}", building.name)),
+            Name::new(format!("Building {}", self.name)),
             view::CullingRect(building.base_rect()),
+            view::Named { name: self.name },
             building,
         ));
         entity.reborrow_scope(|entity| view::AddViewableCommand.apply(entity));
@@ -162,7 +161,7 @@ pub struct DespawnCommand;
 impl EntityCommand for DespawnCommand {
     type Out = ();
     fn apply(self, mut entity: EntityWorldMut) {
-        view::on_viewable_despawn(&mut entity);
+        view::before_viewable_despawn(&mut entity);
         entity.despawn();
     }
 }
@@ -197,14 +196,14 @@ impl EntityCommand for RecomputeAmbientVolume {
 fn sphere_volume(radius: f32) -> f32 { radius.powi(3) * PI * 4.0 / 3.0 }
 
 fn init_viewer_system(
-    building_query: Query<(&Building, &view::Viewable)>,
+    building_query: Query<(&Building, &view::Named, &view::Viewable)>,
     mut messages: MessageWriter<view::SentUpdate>,
 ) {
-    for (building, viewable) in building_query {
+    for (building, named, viewable) in building_query {
         messages.write_batch(viewable.broadcast_new(|| {
             [proto::Update::NewBuilding(proto::NewBuilding {
                 id:             viewable.id,
-                name:           building.name.clone(),
+                name:           named.name.clone(),
                 position:       building.position,
                 radius:         building.radius,
                 wall_thickness: building.wall_thickness,

--- a/physics/src/graph/building/persist.rs
+++ b/physics/src/graph/building/persist.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 use crate::graph::{Building, building};
 use crate::persist::{Depend, InputContext, OutputContext, Persistable};
 use crate::util::EntityWorldMutExt;
-use crate::{Vector, WorldObject, fluid, persist};
+use crate::{Vector, WorldObject, fluid, persist, view};
 
 #[derive(Clone)]
 pub struct Persist;
@@ -33,7 +33,7 @@ impl Persistable for Persist {
             .iter()
             .map(|data| Entry {
                 id:             ctx.alloc(data.entity),
-                name:           data.building.name.clone(),
+                name:           data.named.name.clone(),
                 position:       data.building.position,
                 radius:         data.building.radius,
                 wall_thickness: data.building.wall_thickness,
@@ -82,6 +82,7 @@ pub struct OutputParams<'w, 's> {
 struct OutputQueryData {
     entity:   Entity,
     building: &'static Building,
+    named:    &'static view::Named,
     fluid:    &'static fluid::Storage,
 }
 

--- a/physics/src/graph/conduit.rs
+++ b/physics/src/graph/conduit.rs
@@ -47,7 +47,6 @@ impl Plugin for Plug {
 
 #[derive(Component, Reflect)]
 pub struct Conduit {
-    pub name:   String,
     pub radius: f32,
     pub ty:     ConduitType,
 }
@@ -93,13 +92,13 @@ impl EntityCommand for SpawnCommand {
         entity.insert((
             Name::new("Conduit"),
             Conduit {
-                name:   self.name,
                 radius: self.radius,
                 ty:     match self.typed {
                     TypedSpawn::FluidPipe => ConduitType::FluidPipe,
                 },
             },
             OfCorridor(self.corridor),
+            view::Named { name: self.name },
             corridor_rect,
         ));
         entity.reborrow_scope(|entity| view::AddViewableCommand.apply(entity));
@@ -120,17 +119,27 @@ impl EntityCommand for SpawnCommand {
     }
 }
 
+pub struct DespawnCommand;
+
+impl EntityCommand for DespawnCommand {
+    type Out = ();
+    fn apply(self, mut entity: EntityWorldMut) {
+        view::before_viewable_despawn(&mut entity);
+        entity.despawn();
+    }
+}
+
 fn init_viewer_system(
-    conduit_query: Query<(&Conduit, &view::Viewable, &OfCorridor)>,
+    conduit_query: Query<(&Conduit, &view::Named, &view::Viewable, &OfCorridor)>,
     corridor_query: Query<&view::Viewable, With<Corridor>>,
     mut messages: MessageWriter<view::SentUpdate>,
 ) {
-    for (conduit, viewable, &OfCorridor(corridor_entity)) in conduit_query {
+    for (conduit, named, viewable, &OfCorridor(corridor_entity)) in conduit_query {
         messages.write_batch(viewable.broadcast_new(|| {
             let corridor_viewable = corridor_query.log_get(corridor_entity)?;
             Some(proto::Update::NewConduit(proto::NewConduit {
                 id:       viewable.id,
-                name:     conduit.name.clone(),
+                name:     named.name.clone(),
                 corridor: corridor_viewable.id,
                 radius:   conduit.radius,
                 ty:       match conduit.ty {

--- a/physics/src/graph/conduit/persist.rs
+++ b/physics/src/graph/conduit/persist.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 use crate::graph::{Conduit, ConduitType, conduit, corridor};
 use crate::persist::{Depend, InputContext, OutputContext, Persistable};
 use crate::util::EntityWorldMutExt;
-use crate::{WorldObject, fluid, persist};
+use crate::{WorldObject, fluid, persist, view};
 
 #[derive(Clone)]
 pub struct Persist;
@@ -37,7 +37,7 @@ impl Persistable for Persist {
                 Ok(Entry {
                     id:       ctx.alloc(data.entity),
                     corridor: ctx.get_id(data.corridor.0)?,
-                    name:     data.conduit.name.clone(),
+                    name:     data.named.name.clone(),
                     radius:   data.conduit.radius,
                     ty:       data.conduit.ty,
                     fluid:    data.fluid.map(fluid::persist::StorageEntry::from_component),
@@ -94,6 +94,7 @@ struct OutputQueryData {
     entity:   Entity,
     corridor: &'static conduit::OfCorridor,
     conduit:  &'static Conduit,
+    named:    &'static view::Named,
     fluid:    Option<&'static fluid::Storage>,
 }
 

--- a/physics/src/graph/corridor.rs
+++ b/physics/src/graph/corridor.rs
@@ -52,7 +52,6 @@ impl Plugin for Plug {
 
 #[derive(Component, Reflect)]
 pub struct Corridor {
-    pub name:               String,
     pub length:             f32,
     pub radius:             f32,
     pub wall_thickness:     f32,
@@ -85,8 +84,8 @@ impl EntityCommand for SpawnCommand {
         let length = self.endpoint_positions.net_diff().length();
         entity.insert((
             Name::new(format!("Corridor {name}")),
+            view::Named { name },
             Corridor {
-                name,
                 length,
                 radius: self.radius,
                 wall_thickness: self.wall_thickness,
@@ -165,7 +164,7 @@ pub struct DespawnCommand;
 impl EntityCommand for DespawnCommand {
     type Out = ();
     fn apply(self, mut entity: EntityWorldMut) {
-        view::on_viewable_despawn(&mut entity);
+        view::before_viewable_despawn(&mut entity);
         entity.despawn();
     }
 }
@@ -199,14 +198,14 @@ impl EntityCommand for RecomputeAmbientVolume {
 }
 
 fn init_viewer_system(
-    corridor_query: Query<(&Corridor, &view::Viewable)>,
+    corridor_query: Query<(&Corridor, &view::Named, &view::Viewable)>,
     mut messages: MessageWriter<view::SentUpdate>,
 ) {
-    for (corridor, viewable) in corridor_query {
+    for (corridor, named, viewable) in corridor_query {
         messages.write_batch(viewable.broadcast_new(|| {
             [proto::Update::NewCorridor(proto::NewCorridor {
                 id:             viewable.id,
-                name:           corridor.name.clone(),
+                name:           named.name.clone(),
                 alpha_position: corridor.endpoint_positions.alpha,
                 beta_position:  corridor.endpoint_positions.beta,
                 radius:         corridor.radius,

--- a/physics/src/graph/corridor/persist.rs
+++ b/physics/src/graph/corridor/persist.rs
@@ -10,7 +10,7 @@ use snafu::Snafu;
 use crate::graph::{Corridor, corridor};
 use crate::persist::{Depend, InputContext, OutputContext, Persistable};
 use crate::util::{AlphaBeta, EntityWorldMutExt};
-use crate::{Vector, WorldObject, fluid, persist};
+use crate::{Vector, WorldObject, fluid, persist, view};
 
 #[derive(Clone)]
 pub struct Persist;
@@ -34,7 +34,7 @@ impl Persistable for Persist {
             .map(|data| {
                 Ok(Entry {
                     id:                 ctx.alloc(data.entity),
-                    name:               data.corridor.name.clone(),
+                    name:               data.named.name.clone(),
                     radius:             data.corridor.radius,
                     wall_thickness:     data.corridor.wall_thickness,
                     endpoint_positions: data.corridor.endpoint_positions,
@@ -83,6 +83,7 @@ pub struct OutputParams<'w, 's> {
 struct OutputQueryData {
     entity:   Entity,
     corridor: &'static Corridor,
+    named:    &'static view::Named,
     fluid:    &'static fluid::Storage,
 }
 

--- a/physics/src/graph/facility.rs
+++ b/physics/src/graph/facility.rs
@@ -55,7 +55,6 @@ impl Plugin for Plug {
 
 #[derive(Component, Reflect)]
 pub struct Facility {
-    pub name:   String,
     pub volume: f32,
 }
 
@@ -120,10 +119,11 @@ impl EntityCommand for SpawnCommand {
             .unwrap_or_default();
 
         entity.insert((
-            Name::new("Facility"),
+            Name::new(format!("Facility {name}")),
             FacilityType(self.ty),
             OfBuilding(self.building),
-            Facility { name, volume },
+            Facility { volume },
+            view::Named { name },
             building_rect,
         ));
         entity.reborrow_scope(|entity| view::AddViewableCommand.apply(entity));
@@ -137,9 +137,20 @@ impl EntityCommand for SpawnCommand {
     }
 }
 
+pub struct DespawnCommand;
+
+impl EntityCommand for DespawnCommand {
+    type Out = ();
+    fn apply(self, mut entity: EntityWorldMut) {
+        view::before_viewable_despawn(&mut entity);
+        entity.despawn();
+    }
+}
+
 fn init_viewer_system(
     facility_query: Query<(
         &Facility,
+        &view::Named,
         &view::Viewable,
         &FacilityType,
         &OfBuilding,
@@ -149,8 +160,14 @@ fn init_viewer_system(
     type_query: Query<&FacilityTypeDef>,
     mut messages: MessageWriter<view::SentUpdate>,
 ) {
-    for (facility, viewable, &FacilityType(ty), &OfBuilding(building_entity), fluid_storage) in
-        facility_query
+    for (
+        facility,
+        named,
+        viewable,
+        &FacilityType(ty),
+        &OfBuilding(building_entity),
+        fluid_storage,
+    ) in facility_query
     {
         messages.write_batch(viewable.broadcast_new(|| {
             let building_viewable = building_query.log_get(building_entity)?;
@@ -158,7 +175,7 @@ fn init_viewer_system(
             Some(proto::Update::NewFacility(proto::NewFacility {
                 id:       viewable.id,
                 building: building_viewable.id,
-                name:     facility.name.clone(),
+                name:     named.name.clone(),
                 volume:   facility.volume,
                 display:  proto::FacilityDisplay {
                     sprite_id: typedef.sprite_id.clone(),

--- a/physics/src/graph/facility/persist.rs
+++ b/physics/src/graph/facility/persist.rs
@@ -11,7 +11,7 @@ use crate::graph::facility::{self, PersistTypes, blueprint};
 use crate::graph::{Facility, building};
 use crate::persist::{Depend, InputContext, OutputContext, Persistable};
 use crate::util::EntityWorldMutExt;
-use crate::{WorldObject, fluid, persist, reactor};
+use crate::{WorldObject, fluid, persist, reactor, view};
 
 #[derive(Clone)]
 pub struct Persist;
@@ -41,7 +41,7 @@ impl Persistable for Persist {
             .map(|data| {
                 Ok(Entry {
                     id:               ctx.alloc(data.entity),
-                    name:             data.facility.name.clone(),
+                    name:             data.named.name.clone(),
                     building:         ctx.get_id(data.building.0)?,
                     ty:               ctx.get_id(data.ty.0)?,
                     blueprint_params: BlueprintParams::extract(&data, ctx)?,
@@ -98,6 +98,7 @@ pub struct OutputParams<'w, 's> {
 struct OutputQueryData {
     entity:   Entity,
     facility: &'static Facility,
+    named:    &'static view::Named,
     building: &'static facility::OfBuilding,
     ty:       &'static facility::FacilityType,
     reactor:  Option<&'static reactor::Facility>,

--- a/physics/src/persist.rs
+++ b/physics/src/persist.rs
@@ -199,10 +199,11 @@ impl<P: Persistable> PersistableDyn for P {
 
     #[tracing::instrument(skip_all, fields(ty = self.id().into().as_ref()))]
     fn output(&self, world: &mut World, ctx: &mut OutputContext) -> Result<Vec<u8>, ()> {
-        let output = run_stateless_closure_explicit::<<P as Persistable>::OutputParams<'_, '_>, _, _>(
-            world,
-            |mut param| Persistable::output(self, &mut param, ctx),
-        )?;
+        let output = run_stateless_closure_explicit::<
+            <P as Persistable>::OutputParams<'_, '_>,
+            _,
+            _,
+        >(world, |mut param| Persistable::output(self, &mut param, ctx))?;
         let mut buf = Vec::new();
         match ciborium::into_writer(&output, &mut buf) {
             Ok(()) => {

--- a/physics/src/request.rs
+++ b/physics/src/request.rs
@@ -128,4 +128,5 @@ fan_out! {
     8, 2;
     SetSubscription(view::SetSubscriptionHandler<'w, 's>),
     SetViewFocus(view::SetViewFocusHandler<'w, 's>),
+    RenameViewable(view::RenameViewableHandler<'w, 's>),
 }

--- a/physics/src/resident.rs
+++ b/physics/src/resident.rs
@@ -52,9 +52,7 @@ impl Plugin for Plug {
 }
 
 #[derive(Component, Reflect)]
-pub struct Resident {
-    pub name: String,
-}
+pub struct Resident;
 
 #[derive(Component, Reflect)]
 pub enum Location {
@@ -164,7 +162,8 @@ impl EntityCommand for SpawnCommand {
 
         entity.insert((
             Name::new(format!("Resident {name}")),
-            Resident { name },
+            Resident,
+            view::Named { name },
             Attributes { values: attrs.into_boxed_slice() },
         ));
 
@@ -187,16 +186,32 @@ impl EntityCommand for SpawnCommand {
     }
 }
 
+pub struct DespawnCommand;
+
+impl EntityCommand for DespawnCommand {
+    type Out = ();
+    fn apply(self, mut entity: EntityWorldMut) {
+        view::before_viewable_despawn(&mut entity);
+        entity.despawn();
+    }
+}
+
 fn init_viewer_system(
-    resident_query: Query<(&Resident, &Location, Option<&InteractingWith>, &view::Viewable)>,
+    resident_query: Query<(
+        &Resident,
+        &Location,
+        Option<&InteractingWith>,
+        &view::Named,
+        &view::Viewable,
+    )>,
     viewable_query: Query<(&view::Viewable, Option<&InteractionSlots>)>,
     mut messages: MessageWriter<view::SentUpdate>,
 ) {
-    for (resident, location, interact, viewable) in resident_query {
+    for (resident, location, interact, named, viewable) in resident_query {
         messages.write_batch(viewable.broadcast_new(|| {
             Some(proto::Update::NewResident(proto::NewResident {
                 id:       viewable.id,
-                name:     resident.name.clone(),
+                name:     named.name.clone(),
                 location: make_proto_location(location, interact, &viewable_query)?,
             }))
         }));

--- a/physics/src/resident/persist.rs
+++ b/physics/src/resident/persist.rs
@@ -12,7 +12,7 @@ use crate::graph::{building, corridor, facility};
 use crate::persist::{Depend, InputContext, OutputContext, Persistable};
 use crate::resident::Resident;
 use crate::util::EntityWorldMutExt;
-use crate::{WorldObject, persist, resident};
+use crate::{WorldObject, persist, resident, view};
 
 #[derive(Clone)]
 pub struct Persist;
@@ -43,7 +43,7 @@ impl Persistable for Persist {
             .map(|data| {
                 Ok(Entry {
                     id:       ctx.alloc(data.entity),
-                    name:     data.resident.name.clone(),
+                    name:     data.named.name.clone(),
                     attrs:    data.attrs.values.clone().into(),
                     location: match *data.location {
                         resident::Location::Building { entity, interior_pos } => {
@@ -152,6 +152,7 @@ struct OutputQueryData {
     resident:    &'static Resident,
     location:    &'static resident::Location,
     attrs:       &'static resident::Attributes,
+    named:       &'static view::Named,
     interaction: Option<&'static resident::InteractingWith>,
 }
 

--- a/physics/src/util.rs
+++ b/physics/src/util.rs
@@ -60,7 +60,10 @@ where
     let param = match state.get_mut(world) {
         Ok(param) => param,
         Err(err) => {
-            panic!("Failed to prepare system parameter {} in world: {err}", std::any::type_name::<P>())
+            panic!(
+                "Failed to prepare system parameter {} in world: {err}",
+                std::any::type_name::<P>()
+            )
         }
     };
     let result = f(param);

--- a/physics/src/view.rs
+++ b/physics/src/view.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::time::Duration;
 use std::{iter, mem};
@@ -6,9 +7,10 @@ use bevy::app::{self, App, Plugin};
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::{Entity, EntityHashMap, EntityHashSet};
 use bevy::ecs::message::{Message, MessageWriter};
+use bevy::ecs::query::{Has, With};
 use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::{IntoScheduleConfigs, SystemSet};
-use bevy::ecs::system::{EntityCommand, Query, SystemParam};
+use bevy::ecs::system::{EntityCommand, Query, Res, SystemParam};
 use bevy::ecs::world::EntityWorldMut;
 use bevy::math::{Rect, Vec2};
 use bevy::reflect::Reflect;
@@ -19,17 +21,20 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use traffloat_proto::proto;
 
-use crate::request;
 use crate::util::{self, QueryExt, Throttle};
+use crate::{CleanupAppExt, request};
 
 pub struct Plug;
 
 impl Plugin for Plug {
     fn build(&self, app: &mut App) {
         app.register_type::<Viewer>();
+        app.register_type::<Named>();
         app.register_type::<NextProtoId>();
+        app.register_type::<IdIndex>();
 
         app.init_resource::<NextProtoId>();
+        app.init_resource::<IdIndex>();
         app.add_message::<SentUpdate>();
         util::configure_enum_system_set::<SendUpdatesSystemSet>(app, app::Update);
         for set in SendUpdatesSystemSet::iter() {
@@ -40,6 +45,7 @@ impl Plugin for Plug {
             app::Update,
             reconcile_subscription_system.in_set(SendUpdatesSystemSet::Pair),
         );
+        app.add_cleanup_hook(|world| world.resource_mut::<IdIndex>().index.clear());
     }
 }
 
@@ -57,6 +63,11 @@ struct NextProtoId(proto::Id);
 
 impl Default for NextProtoId {
     fn default() -> Self { NextProtoId(proto::Id(const { NonZeroU32::new(1).unwrap() })) }
+}
+
+#[derive(Resource, Reflect, Default)]
+struct IdIndex {
+    index: HashMap<proto::Id, Entity>,
 }
 
 #[derive(Component, Reflect, Default)]
@@ -292,6 +303,12 @@ impl Viewable {
     }
 }
 
+/// Optional component on viewables that can be renamed.
+#[derive(Component, Reflect)]
+pub struct Named {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct SubscriptionChange {
     old: Option<SubscriptionLevel>,
@@ -363,6 +380,9 @@ impl EntityCommand for AddViewableCommand {
             id,
             new_subscribers: SortedSubscriptionChanges::default(),
         });
+
+        let entity_id = entity.id();
+        entity.resource_mut::<IdIndex>().index.insert(id, entity_id);
     }
 }
 
@@ -426,7 +446,9 @@ fn reconcile_subscription_system(mut params: ReconcileSubscriptionParams) {
     }
 }
 
-pub fn on_viewable_despawn(entity: &mut EntityWorldMut) {
+/// Call before despawning a viewable entity previously added with [`AddViewableCommand`].
+/// Must be called before calling despawn.
+pub fn before_viewable_despawn(entity: &mut EntityWorldMut) {
     let Some(viewable) = entity.get::<Viewable>() else { return };
     let viewers: EntityHashSet =
         viewable.subscribers.iter().flat_map(|(_, s)| s).copied().collect();
@@ -439,6 +461,8 @@ pub fn on_viewable_despawn(entity: &mut EntityWorldMut) {
             });
         });
     }
+
+    entity.resource_mut::<IdIndex>().index.remove(&id);
 }
 
 #[derive(Message)]
@@ -488,4 +512,68 @@ impl request::Handler for SetViewFocusHandler<'_, '_> {
         let Some(mut viewer) = self.viewer_query.log_get_mut(viewer) else { return };
         viewer.focus_requests.clone_from(&request.focus);
     }
+}
+
+#[derive(SystemParam)]
+pub(crate) struct RenameViewableHandler<'w, 's> {
+    viewable_query: Query<'w, 's, (Option<&'static mut Named>, &'static Viewable)>,
+    index:          Res<'w, IdIndex>,
+    update_writer:  MessageWriter<'w, SentUpdate>,
+}
+
+impl request::Handler for RenameViewableHandler<'_, '_> {
+    type Request = proto::RenameViewable;
+
+    fn classify(request: &Self::Request) -> request::HandlerClass { request::HandlerClass::Mutate }
+
+    fn handle(&mut self, viewer: Entity, request: &Self::Request) {
+        let viewable_entity = self
+            .index
+            .index
+            .get(&request.id)
+            .and_then(|&viewable_entity| self.viewable_query.log_get_mut(viewable_entity));
+        match viewable_entity {
+            None => {
+                send_error_toast(
+                    &mut self.update_writer,
+                    viewer,
+                    format!("Viewable with id {} not found", request.id.0),
+                );
+            }
+            Some((None, _)) => {
+                send_error_toast(
+                    &mut self.update_writer,
+                    viewer,
+                    format!("Viewable with id {} is not renameable", request.id.0),
+                );
+            }
+            Some((Some(mut named), viewable)) => {
+                if request.name.is_empty() {
+                    send_error_toast(&mut self.update_writer, viewer, "Name cannot be empty");
+                    return;
+                }
+
+                named.name.clone_from(&request.name);
+                self.update_writer.write_batch(viewable.broadcast_update(|_| {
+                    [proto::UpdateViewableName { id: request.id, name: request.name.clone() }
+                        .into()]
+                }));
+            }
+        }
+    }
+}
+
+pub fn send_error_toast(
+    update_writer: &mut MessageWriter<SentUpdate>,
+    viewer: Entity,
+    message: impl Into<String>,
+) {
+    update_writer.write(SentUpdate {
+        viewers: iter::once(viewer).collect(),
+        body:    proto::ShowGenericToast {
+            message: message.into(),
+            ty:      proto::ToastType::Error,
+        }
+        .into(),
+    });
 }

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -60,6 +60,7 @@ pub enum AlphaOrBeta {
 pub enum Update {
     SetFluidTypes(SetFluidTypes),
     SetResidentAttrTypes(SetResidentAttrTypes),
+    ShowGenericToast(ShowGenericToast),
     NewBuilding(NewBuilding),
     UpdateBuilding(UpdateBuilding),
     UpdateBuildingFluidConnections(UpdateBuildingFluidConnections),
@@ -75,6 +76,7 @@ pub enum Update {
     UpdateResidentLocation(UpdateResidentLocation),
     UpdateResidentAttributesFull(UpdateResidentAttributesFull),
     UpdateResidentAttributesPartial(UpdateResidentAttributesPartial),
+    UpdateViewableName(UpdateViewableName),
     RemoveViewable(RemoveViewable),
 }
 
@@ -119,6 +121,20 @@ bitflags::bitflags! {
     pub struct ResidentAttrNiche: u16 {
         const SIZE = 1 << 0;
     }
+}
+
+/// Shows a generic toast message to the viewer.
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+pub struct ShowGenericToast {
+    pub message: String,
+    pub ty:      ToastType,
+}
+
+/// Display style for toast messages.
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+pub enum ToastType {
+    Info,
+    Error,
 }
 
 /// Subscribed to a new building.
@@ -300,6 +316,12 @@ pub enum ResidentLocation {
     Facility { facility: Id, slot_name: String },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+pub struct UpdateViewableName {
+    pub id:   Id,
+    pub name: String,
+}
+
 /// Unsubscribed from a viewable.
 #[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
 pub struct RemoveViewable {
@@ -320,11 +342,13 @@ pub struct RemoveViewable {
 pub enum Request {
     SetSubscription(SetSubscription),
     SetViewFocus(SetViewFocus),
+    RenameViewable(RenameViewable),
 }
 
 /// Sets the viewer subscription config.
 #[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
 pub struct SetSubscription {
+    /// The rectangles bounding the region that the viewer is currently viewing.
     pub viewports: Vec<Rect>,
     pub debug:     bool,
 }
@@ -333,4 +357,13 @@ pub struct SetSubscription {
 #[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
 pub struct SetViewFocus {
     pub focus: Vec<Id>,
+}
+
+/// Renames a viewable.
+#[derive(Debug, Clone, Serialize, Deserialize, Reflect)]
+pub struct RenameViewable {
+    pub id:   Id,
+    /// The new name of the viewable.
+    /// Must not be empty.
+    pub name: String,
 }


### PR DESCRIPTION
TODO a few refactors to migrate to shared `view::Named` component:
- [x] buildings
- [x] corridors
- [x] facilities
- [x] conduits
- [x] residents